### PR TITLE
Fix tag filter command

### DIFF
--- a/cli/helpers/osmium.js
+++ b/cli/helpers/osmium.js
@@ -66,7 +66,7 @@ export async function tagsFilter(inputFile, filters, outputFile) {
     inputFile,
     "-v",
     "--overwrite",
-    filters,
+    ...filters,
     "-o",
     outputFile,
   ]);


### PR DESCRIPTION
This corrects a minor bug that I inadvertently introduced while refactoring the 'fetch-full-history' task in https://github.com/vgeorge/osm-for-cities/pull/43. The issue is causing the 'tag-filter' command to not filter all preset tags, resulting in only a small amount of data being pushed to the git repositories

cc @osm-for-cities/maintainers 